### PR TITLE
Add guided Accessibility permission onboarding

### DIFF
--- a/WindowSnap/Tests/WindowSnapTests/AccessibilityOnboardingModelTests.swift
+++ b/WindowSnap/Tests/WindowSnapTests/AccessibilityOnboardingModelTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import WindowSnap
+
+final class AccessibilityOnboardingModelTests: XCTestCase {
+    func testCleanInstallWithoutPermissionPresentsOnboarding() {
+        let store = InMemoryOnboardingStore(hasCompletedAccessibilityOnboarding: false)
+        let permissions = StubAccessibilityPermissionProvider(status: .notGranted)
+        let model = AccessibilityOnboardingModel(permissionProvider: permissions, store: store)
+
+        XCTAssertTrue(model.shouldPresentOnLaunch)
+        XCTAssertEqual(model.status, .notGranted)
+        XCTAssertFalse(model.canFinish)
+        XCTAssertEqual(permissions.requestCount, 0)
+    }
+
+    func testCheckingLaunchStateNeverRequestsSystemPermission() {
+        let permissions = StubAccessibilityPermissionProvider(status: .notGranted)
+        let model = AccessibilityOnboardingModel(
+            permissionProvider: permissions,
+            store: InMemoryOnboardingStore(hasCompletedAccessibilityOnboarding: false)
+        )
+
+        _ = model.shouldPresentOnLaunch
+        model.refreshPermissionStatus()
+
+        XCTAssertEqual(permissions.requestCount, 0)
+    }
+
+    func testExplicitRequestIsTheOnlyActionThatRequestsSystemPermission() {
+        let permissions = StubAccessibilityPermissionProvider(status: .notGranted)
+        let model = AccessibilityOnboardingModel(
+            permissionProvider: permissions,
+            store: InMemoryOnboardingStore(hasCompletedAccessibilityOnboarding: false)
+        )
+
+        model.requestPermission()
+
+        XCTAssertEqual(permissions.requestCount, 1)
+    }
+
+    func testRefreshReflectsPermissionGrantedInSystemSettings() {
+        let permissions = StubAccessibilityPermissionProvider(status: .notGranted)
+        let model = AccessibilityOnboardingModel(
+            permissionProvider: permissions,
+            store: InMemoryOnboardingStore(hasCompletedAccessibilityOnboarding: false)
+        )
+
+        permissions.status = .granted
+        model.refreshPermissionStatus()
+
+        XCTAssertEqual(model.status, .granted)
+        XCTAssertTrue(model.canFinish)
+    }
+
+    func testFinishPersistsCompletionOnlyAfterPermissionIsGranted() {
+        let store = InMemoryOnboardingStore(hasCompletedAccessibilityOnboarding: false)
+        let permissions = StubAccessibilityPermissionProvider(status: .notGranted)
+        let model = AccessibilityOnboardingModel(permissionProvider: permissions, store: store)
+
+        XCTAssertFalse(model.finish())
+        XCTAssertFalse(store.hasCompletedAccessibilityOnboarding)
+
+        permissions.status = .granted
+        model.refreshPermissionStatus()
+
+        XCTAssertTrue(model.finish())
+        XCTAssertTrue(store.hasCompletedAccessibilityOnboarding)
+    }
+
+    func testCompletionIsIndependentFromLaterPermissionChanges() {
+        let store = InMemoryOnboardingStore(hasCompletedAccessibilityOnboarding: true)
+        let permissions = StubAccessibilityPermissionProvider(status: .notGranted)
+        let model = AccessibilityOnboardingModel(permissionProvider: permissions, store: store)
+
+        XCTAssertFalse(model.shouldPresentOnLaunch)
+        XCTAssertTrue(model.hasCompletedOnboarding)
+        XCTAssertEqual(model.status, .notGranted)
+    }
+
+    func testExistingAuthorizedUserIsNotShownOnboarding() {
+        let store = InMemoryOnboardingStore(hasCompletedAccessibilityOnboarding: false)
+        let permissions = StubAccessibilityPermissionProvider(status: .granted)
+        let model = AccessibilityOnboardingModel(
+            permissionProvider: permissions,
+            store: store
+        )
+
+        XCTAssertFalse(model.shouldPresentOnLaunch)
+        XCTAssertTrue(model.canFinish)
+        XCTAssertTrue(store.hasCompletedAccessibilityOnboarding)
+    }
+
+    func testUnavailableStatusIsExposedAsActionableState() {
+        let permissions = StubAccessibilityPermissionProvider(status: .unavailable("Permission status could not be read"))
+        let model = AccessibilityOnboardingModel(
+            permissionProvider: permissions,
+            store: InMemoryOnboardingStore(hasCompletedAccessibilityOnboarding: false)
+        )
+
+        XCTAssertEqual(model.status, .unavailable("Permission status could not be read"))
+        XCTAssertFalse(model.canFinish)
+        XCTAssertTrue(model.shouldPresentOnLaunch)
+    }
+
+    func testOpenSettingsDelegatesWithoutRequestingPermission() {
+        let permissions = StubAccessibilityPermissionProvider(status: .notGranted)
+        let model = AccessibilityOnboardingModel(
+            permissionProvider: permissions,
+            store: InMemoryOnboardingStore(hasCompletedAccessibilityOnboarding: false)
+        )
+
+        model.openSystemSettings()
+
+        XCTAssertEqual(permissions.openSettingsCount, 1)
+        XCTAssertEqual(permissions.requestCount, 0)
+    }
+}
+
+private final class StubAccessibilityPermissionProvider: AccessibilityPermissionProviding {
+    var status: AccessibilityAuthorizationStatus
+    private(set) var requestCount = 0
+    private(set) var openSettingsCount = 0
+
+    init(status: AccessibilityAuthorizationStatus) {
+        self.status = status
+    }
+
+    func currentStatus() -> AccessibilityAuthorizationStatus { status }
+    func requestPermission() { requestCount += 1 }
+    func openSystemSettings() { openSettingsCount += 1 }
+}
+
+private final class InMemoryOnboardingStore: AccessibilityOnboardingStoring {
+    var hasCompletedAccessibilityOnboarding: Bool
+
+    init(hasCompletedAccessibilityOnboarding: Bool) {
+        self.hasCompletedAccessibilityOnboarding = hasCompletedAccessibilityOnboarding
+    }
+}

--- a/WindowSnap/WindowSnap/App/AppDelegate.swift
+++ b/WindowSnap/WindowSnap/App/AppDelegate.swift
@@ -12,6 +12,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var snippetPickerWindow: SnippetPickerWindow?
     private var textExpanderManager: TextExpanderManager?
     private var textExpansionEngine: TextExpansionEngine?
+    private var accessibilityOnboardingWindow: AccessibilityOnboardingWindowController?
     private var healthCheckTimer: Timer?
     private var pendingWakeRecovery: DispatchWorkItem?
     private var isRecoveringFromWake = false
@@ -24,7 +25,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func applicationDidFinishLaunching(_ notification: Notification) {
         setupMenuBarApp()
-        requestAccessibilityPermissions()
         initializeManagers()
         setupSleepWakeNotifications()
         startHealthCheck()
@@ -32,19 +32,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Initialize launch at login state
         initializeLaunchAtLogin()
         
-        // Show launch at login prompt if needed (first run)
-        showLaunchAtLoginPromptIfNeeded()
-        
         // Set up notification observers
         setupNotificationObservers()
-        
-        // Check screen recording permission status
-        checkScreenRecordingPermissionOnLaunch()
-    }
-    
-    private func checkScreenRecordingPermissionOnLaunch() {
-        if #available(macOS 12.3, *) {
-            ScreenRecordingPermissions.checkPermissionStatusOnLaunch()
+
+        // Explain Accessibility before any system prompt. Optional permissions remain feature-triggered.
+        if !setupAccessibilityOnboarding() {
+            showLaunchAtLoginPromptIfNeeded()
         }
     }
     
@@ -60,24 +53,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.accessory)
     }
     
-    private func requestAccessibilityPermissions() {
-        // Check and prompt for permissions if needed
-        if !AccessibilityPermissions.hasPermissions() {
-            print("⚠️ WindowSnap requires accessibility permissions to function properly.")
-            print("   Prompting for permissions...")
-            
-            // This will show the system permission dialog
-            AccessibilityPermissions.requestPermissions()
-            
-            // Give user time to grant permissions, then check again
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                if !AccessibilityPermissions.hasPermissions() {
-                    print("   You can also grant permissions manually via System Preferences -> Security & Privacy -> Privacy -> Accessibility")
-                }
-            }
-        }
-    }
-    
     private func initializeManagers() {
         windowManager = WindowManager.shared
         shortcutManager = ShortcutManager()
@@ -90,6 +65,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         setupDefaultShortcuts()
         setupTextExpander()
+    }
+
+    @discardableResult
+    private func setupAccessibilityOnboarding() -> Bool {
+        let model = AccessibilityOnboardingModel(
+            permissionProvider: AccessibilityPermissions.shared,
+            store: PreferencesManager.shared
+        )
+        let controller = AccessibilityOnboardingWindowController(model: model)
+        controller.onDismiss = { [weak self] in
+            self?.showLaunchAtLoginPromptIfNeeded()
+        }
+        accessibilityOnboardingWindow = controller
+        statusBarController?.onShowAccessibilitySetup = { [weak self] in
+            self?.accessibilityOnboardingWindow?.present()
+        }
+        return controller.presentIfNeeded()
     }
     
     private func setupTextExpander() {
@@ -303,9 +295,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         print("🔄 Reinitializing WindowSnap after wake...")
         
         if !AccessibilityPermissions.hasPermissions() {
-            print("⚠️ Accessibility permissions lost after wake - requesting again")
-            requestAccessibilityPermissions()
+            print("⚠️ Accessibility permissions unavailable after wake; use Accessibility Setup from the menu to retry")
         }
+        accessibilityOnboardingWindow?.refreshPermissionStatus()
         
         if let windowManager = windowManager, !windowManager.testAccessibility() {
             print("🔧 WindowManager accessibility lost after wake - resetting...")

--- a/WindowSnap/WindowSnap/Core/AccessibilityOnboardingModel.swift
+++ b/WindowSnap/WindowSnap/Core/AccessibilityOnboardingModel.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+enum AccessibilityAuthorizationStatus: Equatable {
+    case notGranted
+    case granted
+    case unavailable(String)
+}
+
+protocol AccessibilityPermissionProviding: AnyObject {
+    func currentStatus() -> AccessibilityAuthorizationStatus
+    func requestPermission()
+    func openSystemSettings()
+}
+
+protocol AccessibilityOnboardingStoring: AnyObject {
+    var hasCompletedAccessibilityOnboarding: Bool { get set }
+}
+
+final class AccessibilityOnboardingModel {
+    private let permissionProvider: AccessibilityPermissionProviding
+    private let store: AccessibilityOnboardingStoring
+
+    private(set) var status: AccessibilityAuthorizationStatus
+
+    init(
+        permissionProvider: AccessibilityPermissionProviding,
+        store: AccessibilityOnboardingStoring
+    ) {
+        self.permissionProvider = permissionProvider
+        self.store = store
+        status = permissionProvider.currentStatus()
+
+        // Existing users may already have granted access before onboarding existed.
+        // Treat that authorization as completed so a later TCC change does not
+        // retroactively turn them into first-run users; the menu retry remains available.
+        if status == .granted {
+            store.hasCompletedAccessibilityOnboarding = true
+        }
+    }
+
+    var hasCompletedOnboarding: Bool {
+        store.hasCompletedAccessibilityOnboarding
+    }
+
+    var shouldPresentOnLaunch: Bool {
+        guard !hasCompletedOnboarding else { return false }
+        return status != .granted
+    }
+
+    var canFinish: Bool {
+        status == .granted
+    }
+
+    func refreshPermissionStatus() {
+        status = permissionProvider.currentStatus()
+    }
+
+    /// Must only be called in direct response to an explicit user action.
+    func requestPermission() {
+        permissionProvider.requestPermission()
+        refreshPermissionStatus()
+    }
+
+    func openSystemSettings() {
+        permissionProvider.openSystemSettings()
+    }
+
+    @discardableResult
+    func finish() -> Bool {
+        guard canFinish else { return false }
+        store.hasCompletedAccessibilityOnboarding = true
+        return true
+    }
+}

--- a/WindowSnap/WindowSnap/Core/PreferencesManager.swift
+++ b/WindowSnap/WindowSnap/Core/PreferencesManager.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class PreferencesManager {
+class PreferencesManager: AccessibilityOnboardingStoring {
     static let shared = PreferencesManager()
     
     private let userDefaults = UserDefaults.standard
@@ -17,6 +17,7 @@ class PreferencesManager {
             "AnimationDuration": 0.3,
             "DefaultMargin": 10.0,
             "HasShownLaunchAtLoginPrompt": false,
+            "HasCompletedAccessibilityOnboarding": false,
             "IsFirstRun": true
         ]
         
@@ -70,6 +71,11 @@ class PreferencesManager {
     var hasShownLaunchAtLoginPrompt: Bool {
         get { userDefaults.bool(forKey: "HasShownLaunchAtLoginPrompt") }
         set { userDefaults.set(newValue, forKey: "HasShownLaunchAtLoginPrompt") }
+    }
+
+    var hasCompletedAccessibilityOnboarding: Bool {
+        get { userDefaults.bool(forKey: "HasCompletedAccessibilityOnboarding") }
+        set { userDefaults.set(newValue, forKey: "HasCompletedAccessibilityOnboarding") }
     }
     
     func markFirstRunComplete() {

--- a/WindowSnap/WindowSnap/UI/AccessibilityOnboardingWindow.swift
+++ b/WindowSnap/WindowSnap/UI/AccessibilityOnboardingWindow.swift
@@ -1,0 +1,244 @@
+import AppKit
+
+final class AccessibilityOnboardingWindowController: NSWindowController, NSWindowDelegate {
+    var onDismiss: (() -> Void)?
+
+    private let model: AccessibilityOnboardingModel
+    private let statusLabel = NSTextField(labelWithString: "")
+    private let statusDetailLabel = NSTextField(wrappingLabelWithString: "")
+    private let requestButton = NSButton(title: "Enable Accessibility", target: nil, action: nil)
+    private let settingsButton = NSButton(title: "Open System Settings", target: nil, action: nil)
+    private let finishButton = NSButton(title: "Finish Setup", target: nil, action: nil)
+    private let readinessLabel = NSTextField(wrappingLabelWithString: "")
+    private let testedButton = NSButton(title: "I've tested a snapping shortcut", target: nil, action: nil)
+    private var activationObserver: NSObjectProtocol?
+    private var didNotifyDismiss = false
+
+    init(model: AccessibilityOnboardingModel) {
+        self.model = model
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 520),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        super.init(window: window)
+        configureWindow()
+        buildContent()
+        observeApplicationActivation()
+        render()
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    deinit {
+        if let activationObserver {
+            NotificationCenter.default.removeObserver(activationObserver)
+        }
+    }
+
+    @discardableResult
+    func presentIfNeeded() -> Bool {
+        model.refreshPermissionStatus()
+        guard model.shouldPresentOnLaunch else { return false }
+        present()
+        return true
+    }
+
+    func present() {
+        didNotifyDismiss = false
+        model.refreshPermissionStatus()
+        render()
+        showWindow(nil)
+        window?.center()
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func refreshPermissionStatus() {
+        model.refreshPermissionStatus()
+        render()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        notifyDismissed()
+    }
+
+    private func configureWindow() {
+        guard let window else { return }
+        window.title = "Welcome to WindowSnap"
+        window.isReleasedWhenClosed = false
+        window.isRestorable = false
+        window.delegate = self
+        window.standardWindowButton(.zoomButton)?.isHidden = true
+    }
+
+    private func buildContent() {
+        guard let contentView = window?.contentView else { return }
+
+        let root = NSStackView()
+        root.orientation = .vertical
+        root.alignment = .leading
+        root.spacing = 16
+        root.edgeInsets = NSEdgeInsets(top: 28, left: 32, bottom: 24, right: 32)
+        root.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(root)
+
+        NSLayoutConstraint.activate([
+            root.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            root.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            root.topAnchor.constraint(equalTo: contentView.topAnchor),
+            root.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+
+        let title = NSTextField(labelWithString: "Set up window snapping")
+        title.font = .systemFont(ofSize: 24, weight: .bold)
+        root.addArrangedSubview(title)
+
+        let introduction = NSTextField(wrappingLabelWithString: "WindowSnap needs Accessibility access so it can move and resize application windows when you use a menu command or keyboard shortcut.")
+        introduction.font = .systemFont(ofSize: 14)
+        root.addArrangedSubview(introduction)
+        introduction.widthAnchor.constraint(equalTo: root.widthAnchor, constant: -64).isActive = true
+
+        let privacyBox = makeBox()
+        let privacyText = NSTextField(wrappingLabelWithString: "Private by design\nWindowSnap works locally on this Mac. No account is required, and this setup does not request Screen Recording or Input Monitoring access.")
+        privacyText.font = .systemFont(ofSize: 13)
+        privacyBox.addSubview(privacyText)
+        privacyText.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            privacyText.leadingAnchor.constraint(equalTo: privacyBox.leadingAnchor, constant: 14),
+            privacyText.trailingAnchor.constraint(equalTo: privacyBox.trailingAnchor, constant: -14),
+            privacyText.topAnchor.constraint(equalTo: privacyBox.topAnchor, constant: 12),
+            privacyText.bottomAnchor.constraint(equalTo: privacyBox.bottomAnchor, constant: -12)
+        ])
+        root.addArrangedSubview(privacyBox)
+        privacyBox.widthAnchor.constraint(equalTo: root.widthAnchor, constant: -64).isActive = true
+
+        let statusTitle = NSTextField(labelWithString: "Accessibility status")
+        statusTitle.font = .systemFont(ofSize: 13, weight: .semibold)
+        root.addArrangedSubview(statusTitle)
+
+        statusLabel.font = .systemFont(ofSize: 15, weight: .semibold)
+        root.addArrangedSubview(statusLabel)
+        root.addArrangedSubview(statusDetailLabel)
+        statusDetailLabel.widthAnchor.constraint(equalTo: root.widthAnchor, constant: -64).isActive = true
+
+        requestButton.target = self
+        requestButton.action = #selector(requestPermission)
+        requestButton.bezelStyle = .rounded
+        settingsButton.target = self
+        settingsButton.action = #selector(openSettings)
+        settingsButton.bezelStyle = .rounded
+
+        let permissionButtons = NSStackView(views: [requestButton, settingsButton])
+        permissionButtons.orientation = .horizontal
+        permissionButtons.spacing = 10
+        root.addArrangedSubview(permissionButtons)
+
+        readinessLabel.stringValue = "Ready to test: focus another app, then press ⌘⇧← to snap its window to the left half. You can reopen this setup from the WindowSnap menu at any time."
+        readinessLabel.font = .systemFont(ofSize: 13)
+        readinessLabel.textColor = .secondaryLabelColor
+        root.addArrangedSubview(readinessLabel)
+        readinessLabel.widthAnchor.constraint(equalTo: root.widthAnchor, constant: -64).isActive = true
+
+        testedButton.target = self
+        testedButton.action = #selector(confirmShortcutTest)
+        testedButton.setButtonType(.switch)
+        root.addArrangedSubview(testedButton)
+
+        let spacer = NSView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .vertical)
+        root.addArrangedSubview(spacer)
+
+        let laterButton = NSButton(title: "Not Now", target: self, action: #selector(dismissWithoutFinishing))
+        laterButton.bezelStyle = .rounded
+        finishButton.target = self
+        finishButton.action = #selector(finishSetup)
+        finishButton.bezelStyle = .rounded
+        finishButton.keyEquivalent = "\r"
+
+        let footer = NSStackView(views: [laterButton, finishButton])
+        footer.orientation = .horizontal
+        footer.spacing = 10
+        footer.distribution = .fillEqually
+        root.addArrangedSubview(footer)
+        footer.widthAnchor.constraint(equalTo: root.widthAnchor, constant: -64).isActive = true
+    }
+
+    private func makeBox() -> NSView {
+        let view = NSView()
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        view.layer?.cornerRadius = 8
+        return view
+    }
+
+    private func observeApplicationActivation() {
+        activationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshPermissionStatus()
+        }
+    }
+
+    private func render() {
+        switch model.status {
+        case .notGranted:
+            statusLabel.stringValue = "Not granted"
+            statusLabel.textColor = .systemOrange
+            statusDetailLabel.stringValue = "Choose Enable Accessibility when you're ready. macOS will then ask for your approval."
+        case .granted:
+            statusLabel.stringValue = "Granted"
+            statusLabel.textColor = .systemGreen
+            statusDetailLabel.stringValue = "WindowSnap is ready to move and resize windows."
+        case .unavailable(let message):
+            statusLabel.stringValue = "Status unavailable"
+            statusLabel.textColor = .systemRed
+            statusDetailLabel.stringValue = "\(message) Open System Settings to verify WindowSnap is enabled, then return here."
+        }
+
+        let granted = model.canFinish
+        requestButton.isHidden = granted
+        finishButton.isEnabled = granted
+        readinessLabel.isHidden = !granted
+        testedButton.isHidden = !granted
+    }
+
+    @objc private func requestPermission() {
+        model.requestPermission()
+        render()
+    }
+
+    @objc private func openSettings() {
+        model.openSystemSettings()
+    }
+
+    @objc private func confirmShortcutTest() {
+        readinessLabel.stringValue = testedButton.state == .on
+            ? "Test confirmed. WindowSnap is ready; choose Finish Setup when you're done."
+            : "Ready to test: focus another app, then press ⌘⇧← to snap its window to the left half."
+    }
+
+    @objc private func finishSetup() {
+        guard model.finish() else {
+            refreshPermissionStatus()
+            return
+        }
+        window?.close()
+    }
+
+    @objc private func dismissWithoutFinishing() {
+        window?.orderOut(nil)
+        notifyDismissed()
+    }
+
+    private func notifyDismissed() {
+        guard !didNotifyDismiss else { return }
+        didNotifyDismiss = true
+        onDismiss?()
+    }
+}

--- a/WindowSnap/WindowSnap/UI/StatusBarController.swift
+++ b/WindowSnap/WindowSnap/UI/StatusBarController.swift
@@ -2,6 +2,7 @@ import AppKit
 import Foundation
 
 class StatusBarController {
+    var onShowAccessibilitySetup: (() -> Void)?
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
     private var preferencesWindow: PreferencesWindow?
     private var textExpanderWindow: TextExpanderWindow?
@@ -105,6 +106,10 @@ class StatusBarController {
         }
         
         // Settings and Info
+        let accessibilityItem = NSMenuItem(title: "Accessibility Setup…", action: #selector(showAccessibilitySetup), keyEquivalent: "")
+        accessibilityItem.target = self
+        menu.addItem(accessibilityItem)
+
         let preferencesItem = NSMenuItem(title: "Preferences...", action: #selector(showPreferences), keyEquivalent: ",")
         preferencesItem.target = self
         menu.addItem(preferencesItem)
@@ -161,6 +166,10 @@ class StatusBarController {
         preferencesWindow?.showWindow(nil)
         preferencesWindow?.window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @objc private func showAccessibilitySetup() {
+        onShowAccessibilitySetup?()
     }
     
     @objc private func showCustomPositions() {

--- a/WindowSnap/WindowSnap/Utils/AccessibilityPermissions.swift
+++ b/WindowSnap/WindowSnap/Utils/AccessibilityPermissions.swift
@@ -2,7 +2,10 @@ import Foundation
 import ApplicationServices
 import AppKit
 
-class AccessibilityPermissions {
+final class AccessibilityPermissions: AccessibilityPermissionProviding {
+    static let shared = AccessibilityPermissions()
+
+    private init() {}
     
     static func hasPermissions() -> Bool {
         let trusted = AXIsProcessTrusted()
@@ -22,6 +25,18 @@ class AccessibilityPermissions {
     static func requestPermissions() {
         let options = [kAXTrustedCheckOptionPrompt.takeRetainedValue(): true] as CFDictionary
         AXIsProcessTrustedWithOptions(options)
+    }
+
+    func currentStatus() -> AccessibilityAuthorizationStatus {
+        .init(isTrusted: AXIsProcessTrusted())
+    }
+
+    func requestPermission() {
+        Self.requestPermissions()
+    }
+
+    func openSystemSettings() {
+        Self.openSecurityPreferences()
     }
     
     static func showPermissionsAlert() {
@@ -62,5 +77,11 @@ class AccessibilityPermissions {
             showPermissionsAlert()
             return false
         }
+    }
+}
+
+private extension AccessibilityAuthorizationStatus {
+    init(isTrusted: Bool) {
+        self = isTrusted ? .granted : .notGranted
     }
 }

--- a/WindowSnap/docs/ACCESSIBILITY_ONBOARDING_MANUAL_TESTS.md
+++ b/WindowSnap/docs/ACCESSIBILITY_ONBOARDING_MANUAL_TESTS.md
@@ -1,0 +1,55 @@
+# Accessibility onboarding manual verification
+
+These checks exercise macOS TCC behavior that cannot be simulated reliably by unit tests. Run them with a bundled build of WindowSnap on each supported major macOS version (macOS 12 and later).
+
+## Preparation
+
+1. Quit WindowSnap.
+2. Reset the app's Accessibility decision when a clean state is required:
+
+   ```sh
+   tccutil reset Accessibility com.windowsnap.app
+   ```
+
+3. Remove `HasCompletedAccessibilityOnboarding` from the app's preferences, or test with a fresh macOS user account.
+
+Do not reset TCC on a machine where preserving the current permission decision is important.
+
+## Clean-install and grant path
+
+1. Launch WindowSnap with Accessibility not granted.
+2. Confirm the WindowSnap explanation appears before any macOS permission prompt.
+3. Confirm the copy says WindowSnap moves and resizes application windows, works locally, and requires no account.
+4. Confirm the initial state is **Not granted** and **Finish Setup** is disabled.
+5. Confirm neither Screen Recording nor Input Monitoring is requested.
+6. Choose **Enable Accessibility** and confirm this explicit click is what triggers the macOS prompt.
+7. Grant access in System Settings and return to WindowSnap without relaunching it.
+8. Confirm the state changes to **Granted** and **Finish Setup** becomes available.
+9. Focus another app and press ⌘⇧←. Confirm its window snaps to the left half, then use the test confirmation in onboarding.
+10. Finish setup, relaunch WindowSnap, and confirm onboarding does not reappear.
+
+## Deny and retry path
+
+1. Start again from a reset Accessibility decision and incomplete onboarding state.
+2. Choose **Enable Accessibility**, then deny or dismiss the macOS prompt.
+3. Confirm WindowSnap remains running in the menu bar and onboarding continues to show **Not granted**.
+4. Choose **Not Now** and confirm the onboarding closes without quitting or blocking the menu.
+5. Open the menu-bar menu and choose **Accessibility Setup…**.
+6. Confirm onboarding reopens and **Open System Settings** opens Privacy & Security > Accessibility.
+7. Enable WindowSnap in System Settings, return to the app, and confirm the state refreshes to **Granted** without relaunching.
+
+## Existing-user path
+
+1. Grant WindowSnap Accessibility access before launch and clear only the onboarding-completion preference.
+2. Launch WindowSnap.
+3. Confirm onboarding is not presented and snapping shortcuts remain available.
+4. Confirm **Accessibility Setup…** remains available from the menu for status review or troubleshooting.
+
+## Optional-permission isolation
+
+1. With Screen Recording and Input Monitoring reset, launch WindowSnap and complete or dismiss Accessibility onboarding.
+2. Confirm neither optional permission is requested during launch or Accessibility onboarding.
+3. Invoke Region Share and confirm Screen Recording is requested only from that feature flow.
+4. With Text Expander disabled, confirm Input Monitoring is not requested. Enable or use Text Expander and confirm its permission guidance appears only then.
+
+Record the macOS version, architecture, build identifier, and result for each path in the release checklist or pull request.


### PR DESCRIPTION
## Summary

Adds a guided, first-run Accessibility onboarding flow for WindowSnap and removes implicit permission work from app launch and wake recovery.

Closes #14

## What changed

- Adds a testable onboarding state model with injectable permission and persistence boundaries.
- Presents native explanatory UI before any Accessibility request, including local/no-account privacy copy and move/resize rationale.
- Requests Accessibility only from the explicit **Enable Accessibility** action.
- Refreshes status when WindowSnap becomes active after a System Settings round trip.
- Adds **Not Now**, direct System Settings access, a readiness/test step, and a persistent **Accessibility Setup…** menu item.
- Persists completed onboarding separately from live TCC state and migrates already-authorized existing users as complete.
- Removes the startup Screen Recording status probe and the wake-time Accessibility prompt path so optional permissions remain feature-triggered.
- Documents manual macOS TCC verification for clean-install, grant, deny, retry, existing-user, and optional-permission paths.

## TDD evidence

The onboarding tests were written before implementation. During refinement, the existing-authorized-user migration test failed first, then passed after the migration behavior was added.

- Red: `testExistingAuthorizedUserIsNotShownOnboarding` failed because completion had not yet been persisted.
- Green: 9/9 focused onboarding tests pass.
- Regression: 73/73 full Swift tests pass.

## Validation

- `swift test --disable-sandbox` — **73 passed, 0 failed**
- `swift build -c release --disable-sandbox` — **passed**
- `git diff --cached --check` — **passed**

The build still reports pre-existing Swift concurrency and deprecation warnings outside this issue's scope; no new build failure was introduced.

## Acceptance criteria

- [x] Clean-install state routes to explanatory onboarding before a system prompt.
- [x] Accessibility prompt is reachable only from an explicit onboarding action.
- [x] UI explains that access is used to move and resize application windows.
- [x] UI states that WindowSnap works locally and requires no account.
- [x] UI supports `Not granted`, `Granted`, and actionable unavailable/error presentation.
- [x] Status refreshes on app activation after returning from System Settings.
- [x] Button opens the Accessibility privacy pane.
- [x] Granted status enables finishing setup; snapping shortcuts are registered independently of onboarding.
- [x] Denial/dismissal leaves the menu app running and provides **Accessibility Setup…** for retry.
- [x] Screen Recording startup probing was removed; Region Share retains its feature-triggered request flow.
- [x] Input Monitoring is not requested by onboarding or core launch; Text Expander retains its feature-triggered guidance.
- [x] Existing authorized users are migrated as completed and are not shown first-run onboarding.
- [x] Unit tests cover launch decisions, explicit requests, refresh, completion, migration, unavailable state, and Settings delegation.
- [x] Manual verification steps are documented in `WindowSnap/docs/ACCESSIBILITY_ONBOARDING_MANUAL_TESTS.md`.

## Manual verification still required before marking ready

- [ ] Run clean-install, grant, deny, and later-grant TCC paths on supported macOS versions.
- [ ] Confirm the Accessibility deep link on each supported macOS version.
- [ ] Confirm Region Share and Text Expander remain the only triggers for their optional permission flows.
