### PR TITLE
fix: enforce release tag provenance before publishing

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -33,13 +33,27 @@ jobs:
       - name: Resolve checkout ref
         id: checkout_ref
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_TAG: ${{ github.event.inputs.tag }}
+          TRIGGER_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "ref=refs/tags/${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            tag="$REQUESTED_TAG"
           else
-            echo "ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+            [[ "$TRIGGER_REF" =~ ^refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+)$ ]] || {
+              echo "Release ref must be an exact vX.Y.Z tag." >&2
+              exit 1
+            }
+            tag="${BASH_REMATCH[1]}"
           fi
+          [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "Release tag must use the exact vX.Y.Z format." >&2
+            exit 1
+          }
+          echo "ref=refs/tags/$tag" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
         with:
@@ -49,13 +63,11 @@ jobs:
       - name: Resolve release tag
         id: meta
         shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.checkout_ref.outputs.tag }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            tag="${{ github.event.inputs.tag }}"
-          else
-            tag="${GITHUB_REF#refs/tags/}"
-          fi
+          tag="$RELEASE_TAG"
           expected="v$(tr -d '[:space:]' < WindowSnap/VERSION)"
           [[ "$tag" == "$expected" ]] || {
             echo "Tag $tag does not match WindowSnap/VERSION ($expected)." >&2

--- a/DISTRIBUTION_GUIDE.md
+++ b/DISTRIBUTION_GUIDE.md
@@ -20,6 +20,12 @@ Public releases must be universal, signed with a Developer ID Application certif
    export NOTARY_PROFILE="windowsnap-notary"
    ```
 
+4. Configure a GitHub repository ruleset with tag protection for `v*`: restrict
+   creation to release maintainers and prevent tag updates or deletion. Release
+   tags should be immutable after they are pushed. The release script rechecks
+   the remote tag immediately before publishing, but server-side protection is
+   the primary defense against accidental or malicious tag movement.
+
 Do not commit certificates, private keys, passwords, profile exports, or notarization credentials. The scripts intentionally do not print credentials or Keychain contents.
 
 ## Canonical command

--- a/WindowSnap/Tests/release_pipeline_test.sh
+++ b/WindowSnap/Tests/release_pipeline_test.sh
@@ -101,6 +101,7 @@ assert_contains "$ROOT_DIR/../DISTRIBUTION_GUIDE.md" 'scripts/release\.sh' "dist
 assert_contains "$ROOT_DIR/../DISTRIBUTION_GUIDE.md" 'clean-machine|Clean-machine' "distribution guide includes a clean-machine smoke test"
 assert_not_contains "$ROOT_DIR/../DISTRIBUTION_GUIDE.md" '--password[[:space:]]+"?[^[:space:]]+|APP_SPECIFIC_PASSWORD' "distribution guide never places notarization passwords in command arguments"
 assert_contains "$ROOT_DIR/../DISTRIBUTION_GUIDE.md" 'interactive|prompt' "distribution guide uses interactive Keychain credential setup"
+assert_contains "$ROOT_DIR/../DISTRIBUTION_GUIDE.md" 'immutable|tag protection' "distribution guide recommends immutable release tags"
 
 WORKFLOW="$ROOT_DIR/../.github/workflows/release-macos.yml"
 assert_not_contains "$WORKFLOW" 'notarize-dist\.sh|softprops/action-gh-release' "live workflow has no retired or duplicate release path"
@@ -124,6 +125,9 @@ rm -f "$workflow_mutant"
 assert_contains "$SCRIPTS_DIR/release.sh" 'git .*status --porcelain' "publish requires a clean working tree"
 assert_contains "$SCRIPTS_DIR/release.sh" 'git .*ls-remote' "publish verifies the release tag on origin"
 assert_contains "$SCRIPTS_DIR/release.sh" '--verify-tag' "GitHub release creation refuses to invent a missing tag"
+assert_contains "$SCRIPTS_DIR/release.sh" 'EXPECTED_RELEASE_COMMIT' "publish preserves the initially verified release commit"
+assert_contains "$SCRIPTS_DIR/release.sh" 'revalidate_publish_source' "publish revalidates source provenance after building"
+assert_contains "$SCRIPTS_DIR/release.sh" 'BASH_SOURCE\[0\].*\$0' "release functions can be sourced for behavioral tests without running the build"
 
 preflight_tmp="$(mktemp -d)"
 remote_repo="$preflight_tmp/remote.git"
@@ -148,10 +152,103 @@ printf 'dirty\n' >> "$work_repo/untracked.txt"
 assert_publish_preflight_fails_with "$work_repo" "clean working tree" "publish rejects untracked or modified files"
 rm -f "$work_repo/untracked.txt"
 
+printf '\n# tracked mutation\n' >> "$work_repo/scripts/release.sh"
+assert_publish_preflight_fails_with "$work_repo" "clean working tree" "publish rejects a modified tracked file"
+git -C "$work_repo" checkout -- scripts/release.sh
+
 git --git-dir="$remote_repo" update-ref -d refs/tags/v9.8.7
 assert_publish_preflight_fails_with "$work_repo" "Remote tag v9.8.7 does not exist" "publish rejects a missing remote release tag without network access"
 git --git-dir="$remote_repo" update-ref refs/tags/v9.8.7 "$release_tag_object"
 assert_publish_preflight_fails_with "$work_repo" "Set CODESIGN_ID" "publish accepts a clean checkout at the exact annotated remote tag commit"
+
+git --git-dir="$remote_repo" update-ref refs/tags/v9.8.7 "$release_commit"
+assert_publish_preflight_fails_with "$work_repo" "Set CODESIGN_ID" "publish accepts a lightweight remote tag at the exact HEAD commit"
+git --git-dir="$remote_repo" update-ref refs/tags/v9.8.7 "$release_tag_object"
+
+printf 'alternate\n' > "$work_repo/ALTERNATE"
+git -C "$work_repo" add ALTERNATE
+git -C "$work_repo" commit -m "alternate release commit" >/dev/null
+alternate_commit="$(git -C "$work_repo" rev-parse HEAD)"
+git -C "$work_repo" push origin HEAD:refs/heads/test-alternate >/dev/null
+git -C "$work_repo" reset --hard "$release_commit" >/dev/null
+
+mock_gh_log="$preflight_tmp/mock-gh.log"
+run_mocked_publish() {
+  local mutation="${1:-none}"
+  (
+    # shellcheck disable=SC1090
+    source "$work_repo/scripts/release.sh"
+    ROOT_DIR="$work_repo"
+    VERSION="9.8.7"
+    EXPECTED_RELEASE_COMMIT=""
+    DRAFT=false
+    PRODUCTION_DIR="$work_repo/dist/production"
+    ZIP_NAME="WindowSnap-9.8.7-macOS-notarized.zip"
+    DMG_NAME="WindowSnap-9.8.7-macOS-notarized.dmg"
+    gh() { printf '%s\n' "$*" > "$mock_gh_log"; }
+
+    validate_publish_source
+    case "$mutation" in
+      dirty) printf 'changed during build\n' > "$work_repo/build-mutation.txt" ;;
+      head)
+        printf 'head changed\n' > "$work_repo/HEAD-CHANGED"
+        git -C "$work_repo" add HEAD-CHANGED
+        git -C "$work_repo" commit -m "change head during build" >/dev/null
+        ;;
+      remote-delete) git --git-dir="$remote_repo" update-ref -d refs/tags/v9.8.7 ;;
+      remote-move) git --git-dir="$remote_repo" update-ref refs/tags/v9.8.7 "$alternate_commit" ;;
+    esac
+    publish_verified_release
+  )
+}
+
+if grep -Eq '^publish_verified_release\(\)' "$work_repo/scripts/release.sh" && \
+    run_mocked_publish none && \
+    grep -Eq '^release create v9\.8\.7 --verify-tag([[:space:]]|$)' "$mock_gh_log"; then
+  pass "mocked GitHub publishing actually invokes release create with --verify-tag"
+else
+  fail "mocked GitHub publishing actually invokes release create with --verify-tag"
+fi
+
+rm -f "$mock_gh_log"
+if output="$(run_mocked_publish dirty 2>&1)"; then
+  fail "publish revalidation rejects a worktree changed during build"
+elif grep -Fq "clean working tree" <<<"$output" && [[ ! -e "$mock_gh_log" ]]; then
+  pass "publish revalidation rejects a worktree changed during build"
+else
+  fail "publish revalidation rejects a worktree changed during build"
+fi
+rm -f "$work_repo/build-mutation.txt" "$mock_gh_log"
+
+if output="$(run_mocked_publish head 2>&1)"; then
+  fail "publish revalidation rejects HEAD changed during build"
+elif grep -Fq "HEAD changed during release" <<<"$output" && [[ ! -e "$mock_gh_log" ]]; then
+  pass "publish revalidation rejects HEAD changed during build"
+else
+  fail "publish revalidation rejects HEAD changed during build"
+fi
+git -C "$work_repo" reset --hard "$release_commit" >/dev/null
+rm -f "$mock_gh_log"
+
+if output="$(run_mocked_publish remote-delete 2>&1)"; then
+  fail "publish revalidation rejects a release tag deleted during build"
+elif grep -Fq "does not exist" <<<"$output" && [[ ! -e "$mock_gh_log" ]]; then
+  pass "publish revalidation rejects a release tag deleted during build"
+else
+  fail "publish revalidation rejects a release tag deleted during build"
+fi
+git --git-dir="$remote_repo" update-ref refs/tags/v9.8.7 "$release_tag_object"
+rm -f "$mock_gh_log"
+
+if output="$(run_mocked_publish remote-move 2>&1)"; then
+  fail "publish revalidation rejects a release tag moved during build"
+elif grep -Fq "Remote tag v9.8.7 changed during release" <<<"$output" && [[ ! -e "$mock_gh_log" ]]; then
+  pass "publish revalidation rejects a release tag moved during build"
+else
+  fail "publish revalidation rejects a release tag moved during build"
+fi
+git --git-dir="$remote_repo" update-ref refs/tags/v9.8.7 "$release_tag_object"
+rm -f "$mock_gh_log"
 
 printf 'next\n' > "$work_repo/NEXT"
 git -C "$work_repo" add NEXT

--- a/WindowSnap/Tests/release_pipeline_test.sh
+++ b/WindowSnap/Tests/release_pipeline_test.sh
@@ -23,6 +23,48 @@ assert_executable() {
   if [[ -x "$file" ]]; then pass "$description"; else fail "$description"; fi
 }
 
+workflow_run_blocks_contain() {
+  local file="$1" pattern="$2"
+  awk '
+    /^[[:space:]]+run:[[:space:]]*\|[[:space:]]*$/ {
+      in_run = 1
+      match($0, /^[[:space:]]*/)
+      run_indent = RLENGTH
+      next
+    }
+    in_run {
+      if ($0 ~ /^[[:space:]]*$/) {
+        print
+        next
+      }
+      match($0, /^[[:space:]]*/)
+      if (RLENGTH <= run_indent) {
+        in_run = 0
+        next
+      }
+      print
+    }
+  ' "$file" | grep -Eq -- "$pattern"
+}
+
+assert_workflow_run_not_contains() {
+  local file="$1" pattern="$2" description="$3"
+  if workflow_run_blocks_contain "$file" "$pattern"; then fail "$description"; else pass "$description"; fi
+}
+
+assert_publish_preflight_fails_with() {
+  local repo="$1" expected="$2" description="$3"
+  local output
+  if output="$(cd "$repo" && env -u CODESIGN_ID -u NOTARY_PROFILE ./scripts/release.sh --publish 2>&1)"; then
+    fail "$description"
+  elif grep -Fq -- "$expected" <<<"$output"; then
+    pass "$description"
+  else
+    printf 'Expected error containing: %s\nActual output:\n%s\n' "$expected" "$output" >&2
+    fail "$description"
+  fi
+}
+
 assert_executable "$SCRIPTS_DIR/release.sh" "canonical release command is executable"
 assert_executable "$SCRIPTS_DIR/sign-nested-components.sh" "explicit nested signing helper exists"
 assert_executable "$SCRIPTS_DIR/verify-release.sh" "release artifact verifier exists"
@@ -64,6 +106,58 @@ WORKFLOW="$ROOT_DIR/../.github/workflows/release-macos.yml"
 assert_not_contains "$WORKFLOW" 'notarize-dist\.sh|softprops/action-gh-release' "live workflow has no retired or duplicate release path"
 assert_contains "$WORKFLOW" 'scripts/release\.sh[[:space:]]+--publish' "live workflow delegates publishing to the canonical release command"
 assert_contains "$WORKFLOW" 'notarytool store-credentials' "live workflow creates the canonical notarytool Keychain profile"
+assert_workflow_run_not_contains "$WORKFLOW" '\$\{\{[[:space:]]*(github\.event\.inputs\.tag|github\.ref)[[:space:]]*\}\}' "untrusted GitHub context is never interpolated directly into run scripts"
+assert_contains "$WORKFLOW" 'REQUESTED_TAG:[[:space:]]*\$\{\{[[:space:]]*github\.event\.inputs\.tag[[:space:]]*\}\}' "manual tag input enters the shell only through an environment variable"
+assert_contains "$WORKFLOW" 'TRIGGER_REF:[[:space:]]*\$\{\{[[:space:]]*github\.ref[[:space:]]*\}\}' "push ref enters the shell only through an environment variable"
+assert_contains "$WORKFLOW" '\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$' "workflow strictly validates release tags as vX.Y.Z"
+
+workflow_mutant="$(mktemp)"
+cp "$WORKFLOW" "$workflow_mutant"
+sed 's/tag="\$REQUESTED_TAG"/tag="${{ github.event.inputs.tag }}"/' "$WORKFLOW" > "$workflow_mutant"
+if workflow_run_blocks_contain "$workflow_mutant" '\$\{\{[[:space:]]*github\.event\.inputs\.tag[[:space:]]*\}\}'; then
+  pass "workflow injection mutation is detected by the policy test"
+else
+  fail "workflow injection mutation is detected by the policy test"
+fi
+rm -f "$workflow_mutant"
+
+assert_contains "$SCRIPTS_DIR/release.sh" 'git .*status --porcelain' "publish requires a clean working tree"
+assert_contains "$SCRIPTS_DIR/release.sh" 'git .*ls-remote' "publish verifies the release tag on origin"
+assert_contains "$SCRIPTS_DIR/release.sh" '--verify-tag' "GitHub release creation refuses to invent a missing tag"
+
+preflight_tmp="$(mktemp -d)"
+remote_repo="$preflight_tmp/remote.git"
+work_repo="$preflight_tmp/work"
+git init --bare "$remote_repo" >/dev/null
+git init "$work_repo" >/dev/null
+git -C "$work_repo" config user.name "WindowSnap Test"
+git -C "$work_repo" config user.email "windowsnap-test@example.invalid"
+mkdir -p "$work_repo/scripts"
+cp "$SCRIPTS_DIR/release.sh" "$work_repo/scripts/release.sh"
+chmod +x "$work_repo/scripts/release.sh"
+printf '9.8.7\n' > "$work_repo/VERSION"
+git -C "$work_repo" add VERSION scripts/release.sh
+git -C "$work_repo" commit -m "release fixture" >/dev/null
+release_commit="$(git -C "$work_repo" rev-parse HEAD)"
+git -C "$work_repo" tag -a v9.8.7 -m "release fixture tag"
+release_tag_object="$(git -C "$work_repo" rev-parse v9.8.7)"
+git -C "$work_repo" remote add origin "$remote_repo"
+git -C "$work_repo" push origin HEAD:refs/heads/main refs/tags/v9.8.7 >/dev/null
+
+printf 'dirty\n' >> "$work_repo/untracked.txt"
+assert_publish_preflight_fails_with "$work_repo" "clean working tree" "publish rejects untracked or modified files"
+rm -f "$work_repo/untracked.txt"
+
+git --git-dir="$remote_repo" update-ref -d refs/tags/v9.8.7
+assert_publish_preflight_fails_with "$work_repo" "Remote tag v9.8.7 does not exist" "publish rejects a missing remote release tag without network access"
+git --git-dir="$remote_repo" update-ref refs/tags/v9.8.7 "$release_tag_object"
+assert_publish_preflight_fails_with "$work_repo" "Set CODESIGN_ID" "publish accepts a clean checkout at the exact annotated remote tag commit"
+
+printf 'next\n' > "$work_repo/NEXT"
+git -C "$work_repo" add NEXT
+git -C "$work_repo" commit -m "commit after tag" >/dev/null
+assert_publish_preflight_fails_with "$work_repo" "HEAD must exactly match remote tag v9.8.7" "publish rejects HEAD when it differs from the remote tag commit"
+rm -rf "$preflight_tmp"
 
 assert_not_contains "$ROOT_DIR/../README.md" 'scripts/(build_bundle|sign-and-notarize|distribute|package_dmg)\.sh|right-click method' "README contains no legacy distribution or Gatekeeper-bypass instructions"
 assert_not_contains "$SCRIPTS_DIR/package_dmg.sh" 'hdiutil create|codesign.*continuing|NOTARIZE_DMG_STEPS' "legacy package_dmg route cannot create unverified artifacts"

--- a/WindowSnap/scripts/release.sh
+++ b/WindowSnap/scripts/release.sh
@@ -9,104 +9,69 @@ set -euo pipefail
 die() { echo "ERROR: $*" >&2; exit 1; }
 require_command() { command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"; }
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="$ROOT_DIR/dist"
+PRODUCTION_DIR="$DIST_DIR/production"
+APP_NAME="WindowSnap"
+PUBLISH=false
+DRAFT=false
+EXPECTED_RELEASE_COMMIT=""
+
+resolve_remote_tag_commit() {
+  local tag="$1"
+  local remote_refs remote_commit
+
+  remote_refs="$(git -C "$ROOT_DIR" ls-remote --exit-code origin \
+    "refs/tags/$tag" "refs/tags/$tag^{}" 2>/dev/null)" || return 1
+  remote_commit="$(printf '%s\n' "$remote_refs" | \
+    awk '$2 ~ /\^\{\}$/ { print $1; exit }')"
+  if [[ -z "$remote_commit" ]]; then
+    remote_commit="$(printf '%s\n' "$remote_refs" | awk 'NR == 1 { print $1 }')"
+  fi
+  [[ -n "$remote_commit" ]] || return 1
+  printf '%s\n' "$remote_commit"
+}
+
 validate_publish_source() {
   local tag="v$VERSION"
-  local status remote_refs remote_commit head_commit
+  local status remote_commit head_commit
 
   git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 || \
     die "Publishing requires a Git working tree"
   status="$(git -C "$ROOT_DIR" status --porcelain --untracked-files=normal)"
   [[ -z "$status" ]] || die "Publishing requires a clean working tree"
 
-  if ! remote_refs="$(git -C "$ROOT_DIR" ls-remote --exit-code origin \
-      "refs/tags/$tag" "refs/tags/$tag^{}" 2>/dev/null)"; then
+  if ! remote_commit="$(resolve_remote_tag_commit "$tag")"; then
     die "Remote tag $tag does not exist on origin"
   fi
-  remote_commit="$(printf '%s\n' "$remote_refs" | \
-    awk '$2 ~ /\^\{\}$/ { print $1; exit }')"
-  if [[ -z "$remote_commit" ]]; then
-    remote_commit="$(printf '%s\n' "$remote_refs" | awk 'NR == 1 { print $1 }')"
-  fi
-  [[ -n "$remote_commit" ]] || die "Remote tag $tag does not resolve to a commit"
 
   head_commit="$(git -C "$ROOT_DIR" rev-parse HEAD)"
   [[ "$head_commit" == "$remote_commit" ]] || \
     die "HEAD must exactly match remote tag $tag ($remote_commit)"
+  EXPECTED_RELEASE_COMMIT="$remote_commit"
 }
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-DIST_DIR="$ROOT_DIR/dist"
-PRODUCTION_DIR="$DIST_DIR/production"
-APP_NAME="WindowSnap"
-PUBLISH=false
-DRAFT=false
+revalidate_publish_source() {
+  local tag="v$VERSION"
+  local status head_commit remote_commit
 
-for arg in "$@"; do
-  case "$arg" in
-    --publish) PUBLISH=true ;;
-    --draft) DRAFT=true ;;
-    -h|--help)
-      sed -n '3,6p' "$0"
-      exit 0
-      ;;
-    *) die "Unknown option: $arg" ;;
-  esac
-done
+  [[ -n "$EXPECTED_RELEASE_COMMIT" ]] || die "Expected release commit was not preserved"
+  status="$(git -C "$ROOT_DIR" status --porcelain --untracked-files=normal)"
+  [[ -z "$status" ]] || die "Publishing requires a clean working tree; files changed during release"
 
-VERSION="$(tr -d '[:space:]' < "$ROOT_DIR/VERSION")"
-[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]] || die "Invalid VERSION: $VERSION"
+  head_commit="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+  [[ "$head_commit" == "$EXPECTED_RELEASE_COMMIT" ]] || \
+    die "HEAD changed during release; expected $EXPECTED_RELEASE_COMMIT, found $head_commit"
 
-if [[ "$PUBLISH" == true ]]; then
-  require_command git
-  validate_publish_source
-fi
+  if ! remote_commit="$(resolve_remote_tag_commit "$tag")"; then
+    die "Remote tag $tag does not exist on origin during final publish validation"
+  fi
+  [[ "$remote_commit" == "$EXPECTED_RELEASE_COMMIT" ]] || \
+    die "Remote tag $tag changed during release; expected $EXPECTED_RELEASE_COMMIT, found $remote_commit"
+}
 
-[[ "${CODESIGN_ID:-}" == Developer\ ID\ Application:* ]] || \
-  die "Set CODESIGN_ID to an installed Developer ID Application identity"
-[[ -n "${NOTARY_PROFILE:-}" ]] || \
-  die "Set NOTARY_PROFILE to a notarytool Keychain profile"
-
-for command_name in security swift lipo codesign xcrun hdiutil ditto spctl shasum; do
-  require_command "$command_name"
-done
-
-# Match the exact configured identity without printing the Keychain inventory.
-if ! /usr/bin/security find-identity -v -p codesigning 2>/dev/null | /usr/bin/grep -F "\"$CODESIGN_ID\"" >/dev/null; then
-  die "The configured Developer ID Application identity is not installed or valid"
-fi
-if [[ "$PUBLISH" == true ]]; then
-  require_command gh
-  gh auth status >/dev/null 2>&1 || die "GitHub CLI authentication is required for --publish"
-fi
-
-echo "Building WindowSnap $VERSION for production"
-rm -rf "$DIST_DIR"
-mkdir -p "$DIST_DIR"
-"$ROOT_DIR/scripts/build-universal-bundle.sh"
-"$ROOT_DIR/scripts/sign-and-notarize.sh"
-"$ROOT_DIR/scripts/create-signed-dmg.sh" >/dev/null
-
-APP_PATH="$DIST_DIR/$APP_NAME.app"
-SOURCE_ZIP="$DIST_DIR/$APP_NAME.zip"
-SOURCE_DMG="$DIST_DIR/$APP_NAME-$VERSION-macOS-notarized.dmg"
-BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP_PATH/Contents/Info.plist")"
-ZIP_NAME="$APP_NAME-$VERSION-macOS-notarized.zip"
-DMG_NAME="$APP_NAME-$VERSION-macOS-notarized.dmg"
-
-"$ROOT_DIR/scripts/verify-release.sh" "$APP_PATH" "$SOURCE_ZIP" "$SOURCE_DMG" "$VERSION" "$BUILD"
-
-mkdir -p "$PRODUCTION_DIR"
-/usr/bin/ditto "$APP_PATH" "$PRODUCTION_DIR/$APP_NAME.app"
-cp "$SOURCE_ZIP" "$PRODUCTION_DIR/$ZIP_NAME"
-cp "$SOURCE_DMG" "$PRODUCTION_DIR/$DMG_NAME"
-(
-  cd "$PRODUCTION_DIR"
-  /usr/bin/shasum -a 256 "$ZIP_NAME" > "$ZIP_NAME.sha256"
-  /usr/bin/shasum -a 256 "$DMG_NAME" > "$DMG_NAME.sha256"
-)
-
-echo "Verified production artifacts: $PRODUCTION_DIR"
-if [[ "$PUBLISH" == true ]]; then
+publish_verified_release() {
+  local -a release_args
   release_args=(release create "v$VERSION" --verify-tag --title "WindowSnap $VERSION" --generate-notes)
   [[ "$DRAFT" == true ]] && release_args+=(--draft)
   release_args+=(
@@ -115,8 +80,91 @@ if [[ "$PUBLISH" == true ]]; then
     "$PRODUCTION_DIR/$ZIP_NAME.sha256"
     "$PRODUCTION_DIR/$DMG_NAME.sha256"
   )
+
+  # This must remain immediately before GitHub publishing. A release build can
+  # take long enough for the worktree, HEAD, or remote tag to change meanwhile.
+  revalidate_publish_source
   gh "${release_args[@]}"
-  echo "Published only after notarization and full artifact verification."
-else
-  echo "Review these candidates. Create a fresh verified draft with --publish --draft when ready."
+}
+
+main() {
+  local arg
+  PUBLISH=false
+  DRAFT=false
+
+  for arg in "$@"; do
+    case "$arg" in
+      --publish) PUBLISH=true ;;
+      --draft) DRAFT=true ;;
+      -h|--help)
+        sed -n '3,6p' "${BASH_SOURCE[0]}"
+        exit 0
+        ;;
+      *) die "Unknown option: $arg" ;;
+    esac
+  done
+
+  VERSION="$(tr -d '[:space:]' < "$ROOT_DIR/VERSION")"
+  [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]] || die "Invalid VERSION: $VERSION"
+
+  if [[ "$PUBLISH" == true ]]; then
+    require_command git
+    validate_publish_source
+  fi
+
+  [[ "${CODESIGN_ID:-}" == Developer\ ID\ Application:* ]] || \
+    die "Set CODESIGN_ID to an installed Developer ID Application identity"
+  [[ -n "${NOTARY_PROFILE:-}" ]] || \
+    die "Set NOTARY_PROFILE to a notarytool Keychain profile"
+
+  for command_name in security swift lipo codesign xcrun hdiutil ditto spctl shasum; do
+    require_command "$command_name"
+  done
+
+  # Match the exact configured identity without printing the Keychain inventory.
+  if ! /usr/bin/security find-identity -v -p codesigning 2>/dev/null | /usr/bin/grep -F "\"$CODESIGN_ID\"" >/dev/null; then
+    die "The configured Developer ID Application identity is not installed or valid"
+  fi
+  if [[ "$PUBLISH" == true ]]; then
+    require_command gh
+    gh auth status >/dev/null 2>&1 || die "GitHub CLI authentication is required for --publish"
+  fi
+
+  echo "Building WindowSnap $VERSION for production"
+  rm -rf "$DIST_DIR"
+  mkdir -p "$DIST_DIR"
+  "$ROOT_DIR/scripts/build-universal-bundle.sh"
+  "$ROOT_DIR/scripts/sign-and-notarize.sh"
+  "$ROOT_DIR/scripts/create-signed-dmg.sh" >/dev/null
+
+  APP_PATH="$DIST_DIR/$APP_NAME.app"
+  SOURCE_ZIP="$DIST_DIR/$APP_NAME.zip"
+  SOURCE_DMG="$DIST_DIR/$APP_NAME-$VERSION-macOS-notarized.dmg"
+  BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP_PATH/Contents/Info.plist")"
+  ZIP_NAME="$APP_NAME-$VERSION-macOS-notarized.zip"
+  DMG_NAME="$APP_NAME-$VERSION-macOS-notarized.dmg"
+
+  "$ROOT_DIR/scripts/verify-release.sh" "$APP_PATH" "$SOURCE_ZIP" "$SOURCE_DMG" "$VERSION" "$BUILD"
+
+  mkdir -p "$PRODUCTION_DIR"
+  /usr/bin/ditto "$APP_PATH" "$PRODUCTION_DIR/$APP_NAME.app"
+  cp "$SOURCE_ZIP" "$PRODUCTION_DIR/$ZIP_NAME"
+  cp "$SOURCE_DMG" "$PRODUCTION_DIR/$DMG_NAME"
+  (
+    cd "$PRODUCTION_DIR"
+    /usr/bin/shasum -a 256 "$ZIP_NAME" > "$ZIP_NAME.sha256"
+    /usr/bin/shasum -a 256 "$DMG_NAME" > "$DMG_NAME.sha256"
+  )
+
+  echo "Verified production artifacts: $PRODUCTION_DIR"
+  if [[ "$PUBLISH" == true ]]; then
+    publish_verified_release
+    echo "Published only after notarization and full artifact verification."
+  else
+    echo "Review these candidates. Create a fresh verified draft with --publish --draft when ready."
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi

--- a/WindowSnap/scripts/release.sh
+++ b/WindowSnap/scripts/release.sh
@@ -9,6 +9,31 @@ set -euo pipefail
 die() { echo "ERROR: $*" >&2; exit 1; }
 require_command() { command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"; }
 
+validate_publish_source() {
+  local tag="v$VERSION"
+  local status remote_refs remote_commit head_commit
+
+  git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 || \
+    die "Publishing requires a Git working tree"
+  status="$(git -C "$ROOT_DIR" status --porcelain --untracked-files=normal)"
+  [[ -z "$status" ]] || die "Publishing requires a clean working tree"
+
+  if ! remote_refs="$(git -C "$ROOT_DIR" ls-remote --exit-code origin \
+      "refs/tags/$tag" "refs/tags/$tag^{}" 2>/dev/null)"; then
+    die "Remote tag $tag does not exist on origin"
+  fi
+  remote_commit="$(printf '%s\n' "$remote_refs" | \
+    awk '$2 ~ /\^\{\}$/ { print $1; exit }')"
+  if [[ -z "$remote_commit" ]]; then
+    remote_commit="$(printf '%s\n' "$remote_refs" | awk 'NR == 1 { print $1 }')"
+  fi
+  [[ -n "$remote_commit" ]] || die "Remote tag $tag does not resolve to a commit"
+
+  head_commit="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+  [[ "$head_commit" == "$remote_commit" ]] || \
+    die "HEAD must exactly match remote tag $tag ($remote_commit)"
+}
+
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 DIST_DIR="$ROOT_DIR/dist"
 PRODUCTION_DIR="$DIST_DIR/production"
@@ -28,6 +53,14 @@ for arg in "$@"; do
   esac
 done
 
+VERSION="$(tr -d '[:space:]' < "$ROOT_DIR/VERSION")"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]] || die "Invalid VERSION: $VERSION"
+
+if [[ "$PUBLISH" == true ]]; then
+  require_command git
+  validate_publish_source
+fi
+
 [[ "${CODESIGN_ID:-}" == Developer\ ID\ Application:* ]] || \
   die "Set CODESIGN_ID to an installed Developer ID Application identity"
 [[ -n "${NOTARY_PROFILE:-}" ]] || \
@@ -45,9 +78,6 @@ if [[ "$PUBLISH" == true ]]; then
   require_command gh
   gh auth status >/dev/null 2>&1 || die "GitHub CLI authentication is required for --publish"
 fi
-
-VERSION="$(tr -d '[:space:]' < "$ROOT_DIR/VERSION")"
-[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]] || die "Invalid VERSION: $VERSION"
 
 echo "Building WindowSnap $VERSION for production"
 rm -rf "$DIST_DIR"
@@ -77,7 +107,7 @@ cp "$SOURCE_DMG" "$PRODUCTION_DIR/$DMG_NAME"
 
 echo "Verified production artifacts: $PRODUCTION_DIR"
 if [[ "$PUBLISH" == true ]]; then
-  release_args=(release create "v$VERSION" --title "WindowSnap $VERSION" --generate-notes)
+  release_args=(release create "v$VERSION" --verify-tag --title "WindowSnap $VERSION" --generate-notes)
   [[ "$DRAFT" == true ]] && release_args+=(--draft)
   release_args+=(
     "$PRODUCTION_DIR/$ZIP_NAME"


### PR DESCRIPTION
Fixes #17

## Why this follow-up exists

PR #21 merged at `309ee1b`, but independent review found release-integrity blockers still present in `main`:

- GitHub tag/ref context was interpolated directly into release shell steps.
- Publishing did not prove a clean checkout, existing remote tag, or exact HEAD/tag match.
- A later requested-changes review found that those checks were only performed before the long build/notarization process, leaving a provenance drift window before upload.

## What changed

- Pass event name, requested tag, and trigger ref through environment variables only; strictly validate exact `vX.Y.Z` tags before producing outputs.
- Require a clean Git working tree and resolve `refs/tags/v$VERSION` from `origin`, peeling annotated tags and requiring the exact HEAD commit.
- Preserve that verified commit for the duration of the release.
- Immediately before `gh release create`, re-check that the tree is clean, HEAD is unchanged, the remote tag still exists, and it still peels to the preserved commit.
- Use `gh release create --verify-tag` so GitHub cannot invent a missing tag.
- Document a GitHub `v*` ruleset recommendation that prevents tag updates/deletion and restricts tag creation.
- Add policy, mutation, and deterministic local working/bare-repository behavioral tests. They cover tracked and untracked changes, annotated and lightweight tags, HEAD drift, tag deletion/movement, and the actual mocked `gh release create … --verify-tag` invocation.

## TDD evidence

- Initial red phase: 10 failures for expression injection and missing initial provenance checks.
- Requested-changes red phase: 9 failures for missing final revalidation, immutable-tag guidance, sourceable test seam, and build-time mutation behavior.
- Both phases are green after implementation.

## Final verification on latest main

Rebased onto `d18ba79c5e9e4006a3effb694a76a7ad7ae7e943` (clipboard privacy and macOS 13 Launch at Login changes). Both PR #24 deployment requirements and this PR's provenance controls are preserved.

- `WindowSnap/Tests/release_pipeline_test.sh` — all policy, mutation, and behavioral assertions passed
- `bash -n WindowSnap/scripts/*.sh WindowSnap/Tests/release_pipeline_test.sh` — passed
- workflow YAML parse — passed
- `swift test` — 108 tests passed, 0 failures
- `swift build -c release` — passed
- `git diff --check` — passed

Fresh review head: `8b160bfeb37596a59983df0a62bab9c047ba41c2`.

## Review focus

Please review the GitHub expression-to-shell boundary and the final `revalidate_publish_source` call immediately preceding `gh`. This PR remains draft and does not perform a live notarized release or merge itself.